### PR TITLE
Fix code scanning alert no. 2: Incomplete string escaping or encoding

### DIFF
--- a/example/js/example_build.js
+++ b/example/js/example_build.js
@@ -4780,7 +4780,7 @@ function hasOwnProperty(obj, prop) {
         case 'Do':
             return strict ? config._locale._ordinalParse : config._locale._ordinalParseLenient;
         default :
-            a = new RegExp(regexpEscape(unescapeFormat(token.replace('\\', '')), 'i'));
+            a = new RegExp(regexpEscape(unescapeFormat(token.replace(/\\/g, '')), 'i'));
             return a;
         }
     }


### PR DESCRIPTION
Fixes [https://github.com/H3LF4R3/nachie/security/code-scanning/2](https://github.com/H3LF4R3/nachie/security/code-scanning/2)

To fix the problem, we need to ensure that all occurrences of the backslash character are replaced, not just the first one. The best way to achieve this is by using a regular expression with the global flag (`g`). This will ensure that every instance of the backslash character in the string is replaced.

We will modify the `token.replace` call on line 4783 to use a regular expression. Specifically, we will replace `token.replace('\\', '')` with `token.replace(/\\/g, '')`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
